### PR TITLE
chore: add mock task for tests

### DIFF
--- a/lib/sagax.ex
+++ b/lib/sagax.ex
@@ -162,11 +162,11 @@ defmodule Sagax do
 
     case return do
       {:ok, {:error, reason}} ->
-        {:error, %{saga | executed?: true, state: :error, last_result: reason, queue: []}}
+        {:error, reason, %{saga | executed?: true, state: :error, last_result: reason, queue: []}}
       {:ok, result} ->
         result
       {:error, reason} ->
-        {:error, %{saga | executed?: true, state: :error, last_result: reason, queue: []}}
+        {:error, reason, %{saga | executed?: true, state: :error, last_result: reason, queue: []}}
     end
   end
 

--- a/lib/sagax.ex
+++ b/lib/sagax.ex
@@ -153,6 +153,7 @@ defmodule Sagax do
           case execute(saga) do
             {:ok, saga} ->
               {:ok, saga}
+
             {:error, result, _saga} ->
               repo.rollback(result)
           end
@@ -163,8 +164,10 @@ defmodule Sagax do
     case return do
       {:ok, {:error, reason}} ->
         {:error, reason, %{saga | executed?: true, state: :error, last_result: reason, queue: []}}
+
       {:ok, result} ->
         result
+
       {:error, reason} ->
         {:error, reason, %{saga | executed?: true, state: :error, last_result: reason, queue: []}}
     end

--- a/lib/sagax/executer.ex
+++ b/lib/sagax/executer.ex
@@ -2,6 +2,8 @@ defmodule Sagax.Executor do
   @moduledoc false
   alias Sagax.Utils
 
+  @task Application.get_env(:sagax, :task_module, Task)
+
   @spec execute(Sagax.t()) :: Sagax.t()
   def execute(%Sagax{queue: []} = saga), do: saga
   def execute(%Sagax{} = saga), do: do_execute(saga) |> next()
@@ -69,7 +71,7 @@ defmodule Sagax.Executor do
           inner_saga =
             saga.queue
             |> Utils.peek_effect()
-            |> Task.async_stream(
+            |> @task.async_stream(
               fn effect -> do_execute(%{saga | queue: [effect], stack: []}) end,
               saga.opts
             )
@@ -132,7 +134,7 @@ defmodule Sagax.Executor do
   def do_compensate(%Sagax{stack: [{_, items} | tail]} = saga) when is_list(items) do
     inner_saga =
       items
-      |> Task.async_stream(
+      |> @task.async_stream(
         fn item -> {elem(item, 0), do_compensate(%{saga | stack: [item]})} end,
         saga.opts
       )
@@ -248,12 +250,12 @@ defmodule Sagax.Executor do
             {:raise, {exception, __STACKTRACE__}}
         end
       end
-      |> Task.async()
+      |> @task.async()
 
     timeout = Keyword.get(saga_opts, :timeout, 5000)
     timeout = Keyword.get(opts, :timeout, timeout)
 
-    case Task.yield(task, timeout) || Task.shutdown(task, timeout) do
+    case @task.yield(task, timeout) || @task.shutdown(task, timeout) do
       {:ok, result} ->
         result
 

--- a/lib/sagax/executer.ex
+++ b/lib/sagax/executer.ex
@@ -2,7 +2,6 @@ defmodule Sagax.Executor do
   @moduledoc false
   alias Sagax.Utils
 
-
   @spec execute(Sagax.t()) :: Sagax.t()
   def execute(%Sagax{queue: []} = saga), do: saga
   def execute(%Sagax{} = saga), do: do_execute(saga) |> next()

--- a/test/saga_test.exs
+++ b/test/saga_test.exs
@@ -182,11 +182,11 @@ defmodule SagaxTest do
     test "rollbacks transaction on errors" do
       sagax = Sagax.add(Sagax.new(), fn _, _, _, _ -> {:error, "rollback!"} end)
 
-      {:error, saga} = Sagax.transaction(sagax, TestRepo)
+      {:error, reason, saga} = Sagax.transaction(sagax, TestRepo)
 
       assert %Sagax{} = saga
       assert_saga saga, %{state: :error}
-      assert saga.last_result == "rollback!"
+      assert reason == "rollback!"
       assert_receive {:transaction, _fun, []}
     end
   end


### PR DESCRIPTION
With introduction of `transaction/2` it became harder to test sagas
wrapped into a database transaction. The issue is that once you have
a test which spawns a new process which needs to talk to a database
within a transaction, this process cannot obtain a database connection.

```
ExUnit process -> ExUnit transaction -> Sagax transaction -> Task.async -> SQL query from Sagax stage -> error!
```

This somewhat hacky way of mocking Task module should fix the issue.