### PR TITLE
fix: Do not swallow exceptions

### DIFF
--- a/lib/next/state.ex
+++ b/lib/next/state.ex
@@ -109,6 +109,10 @@ defmodule Sagax.Next.State do
     %{state | sagas: sagas, next: Enum.reverse(saga.ops) ++ state.next}
   end
 
+  def apply(_state, _operation, {:raise, {exception, stacktrace}}) do
+    reraise(exception, stacktrace)
+  end
+
   def apply(%State{} = state, operation, _result) when is_op(operation, :run), do: state
 
   # Iterating over compensations that have their result as nil, so we don't need to store

--- a/test/next/executer_test.exs
+++ b/test/next/executer_test.exs
@@ -118,6 +118,14 @@ defmodule Sagax.Next.ExecuterTest do
       assert value == %{"a" => "a", "b" => %{"c" => "c", "d" => "nested HALT!"}, "f" => "f"}
       assert_log log, []
     end
+
+    test "raises an error when step raises an exception" do
+      assert_raise(RuntimeError, "exception", fn ->
+        Sagax.new()
+        |> Sagax.run(fn -> raise "exception" end)
+        |> Sagax.execute()
+      end)
+    end
   end
 
   describe "compensate()" do


### PR DESCRIPTION
Currently, if an unhandled exception happens in one of the steps, a `Sagax` silently stops the saga execution.