### PR TITLE
fix: Use `Sagax.Next` structs in typespecs

### DIFF
--- a/lib/next.ex
+++ b/lib/next.ex
@@ -36,7 +36,7 @@ defmodule Sagax.Next do
   @doc """
   Creates a new saga.
   """
-  @spec new(keyword()) :: Sagax.t()
+  @spec new(keyword()) :: Sagax.Next.t()
   def new(fields \\ []) do
     struct!(
       Sagax,
@@ -47,13 +47,14 @@ defmodule Sagax.Next do
   @doc """
   Calls the executer to execute the given saga.
   """
-  @spec execute(Sagax.t()) :: Sagax.t()
+  @spec execute(Sagax.Next.t()) :: Sagax.Next.t()
   def execute(%Sagax{} = saga), do: Sagax.Executer.execute(saga)
 
   @doc """
   Puts the result of `effect` under `key` in the result of the saga.
   """
-  @spec put(Sagax.t(), atom(), Sagax.Op.effect(), Sagax.Op.compensation()) :: Sagax.t()
+  @spec put(Sagax.Next.t(), atom(), Sagax.Next.Op.effect(), Sagax.Next.Op.compensation()) ::
+          Sagax.Next.t()
   def put(_saga, _key, _effect, comp \\ :noop)
 
   def put(%Sagax{} = saga, key, %Sagax{} = nested_saga, comp) do

--- a/lib/next/builder.ex
+++ b/lib/next/builder.ex
@@ -6,7 +6,7 @@ defmodule Sagax.Next.Builder do
       @doc """
       Initiates and executes the saga with the given `args` and `context`.
       """
-      @spec execute(map(), map(), Keyword.t()) :: {:ok, any()} | {:error, [Sagax.Error.t()]}
+      @spec execute(map(), map(), Keyword.t()) :: {:ok, any()} | {:error, [Sagax.Next.Error.t()]}
       def execute(args, context, opts \\ []) do
         saga =
           args
@@ -24,5 +24,5 @@ defmodule Sagax.Next.Builder do
     end
   end
 
-  @callback new(any, any, []) :: Sagax.t()
+  @callback new(any, any, []) :: Sagax.Next.t()
 end

--- a/lib/next/op.ex
+++ b/lib/next/op.ex
@@ -42,7 +42,7 @@ defmodule Sagax.Next.Op do
   @doc """
   Creates a new put operation.
   """
-  @spec new_put_op(binary(), atom(), effect(), compensation()) :: Op.t()
+  @spec new_put_op(binary(), atom(), effect(), compensation()) :: Saga.Next.Op.t()
   def new_put_op(saga_id, key, effect, comp \\ :noop),
     do:
       op(
@@ -57,7 +57,7 @@ defmodule Sagax.Next.Op do
   @doc """
   Adds an effect to run as part of the saga without storing its result.
   """
-  @spec new_run_op(binary(), effect(), compensation()) :: Op.t()
+  @spec new_run_op(binary(), effect(), compensation()) :: Saga.Next.Op.t()
   def new_run_op(saga_id, effect, comp \\ :noop),
     do: op(id: Utils.new_id(), type: :run, effect: effect, comp: comp, saga_id: saga_id)
 end


### PR DESCRIPTION
We confused Dialyxir a bit by reference the old Sagax structs.