### PR TITLE
feat: Add `Sagax.Next.Builder.compose/2`

### DIFF
--- a/lib/next/builder.ex
+++ b/lib/next/builder.ex
@@ -27,16 +27,16 @@ defmodule Sagax.Next.Builder do
       `builder` function receives the same arguments as any other effect
       (values, args, context).
       """
-      @spec use(Sagax.Next.Op.effect(), Keyword.t()) :: Sagax.Next.Op.effect()
-      def use(builder \\ nil, opts \\ [])
+      @spec compose(Sagax.Next.Op.effect(), Keyword.t()) :: Sagax.Next.Op.effect()
+      def compose(builder \\ nil, opts \\ [])
 
-      def use(nil, opts) do
+      def compose(nil, opts) do
         fn saga, args, context ->
           apply(__MODULE__, :new, [args, context, opts])
         end
       end
 
-      def use(builder, opts) do
+      def compose(builder, opts) do
         fn saga, args, context ->
           args =
             cond do

--- a/lib/next/builder.ex
+++ b/lib/next/builder.ex
@@ -21,6 +21,42 @@ defmodule Sagax.Next.Builder do
             {saga.state, saga.value, saga.context}
         end
       end
+
+      @doc """
+      Enables composition with new `args` based on the current values. The
+      `builder` function receives the same arguments as any other effect
+      (values, args, context).
+      """
+      @spec use(Sagax.Next.Op.effect(), Keyword.t()) :: Sagax.Next.Op.effect()
+      def use(builder \\ nil, opts \\ [])
+
+      def use(nil, opts) do
+        fn saga, args, context ->
+          apply(__MODULE__, :new, [args, context, opts])
+        end
+      end
+
+      def use(builder, opts) do
+        fn saga, args, context ->
+          args =
+            cond do
+              is_function(builder, 1) ->
+                apply(builder, [saga])
+
+              is_function(builder, 2) ->
+                apply(builder, [saga, args])
+
+              is_function(builder, 3) ->
+                apply(builder, [saga, args, context])
+
+              true ->
+                raise ArgumentError,
+                      "Expected builder function to be a function with arity 1,2, or 3"
+            end
+
+          apply(__MODULE__, :new, [args, context, opts])
+        end
+      end
     end
   end
 

--- a/test/next/builder_test.exs
+++ b/test/next/builder_test.exs
@@ -1,80 +1,110 @@
 defmodule Sagax.Next.BuilderTest do
+  alias Sagax.Next, as: Sagax
+
   use ExUnit.Case
 
-  test "executes a succesful saga" do
-    defmodule OkSaga do
-      alias Sagax.Next, as: Sagax
+  describe "execute/3" do
+    test "executes a succesful saga" do
+      defmodule OkSaga do
+        use Sagax.Builder
 
-      use Sagax.Builder
-
-      defp new(args, context, opts) do
-        Sagax.new(args: args, context: context, opts: opts)
-        |> Sagax.put("a", fn -> {:ok, "a"} end)
-        |> Sagax.put("b", fn -> {:ok, "b"} end)
+        def new(args, context, opts) do
+          Sagax.new(args: args, context: context, opts: opts)
+          |> Sagax.put("a", fn -> {:ok, "a"} end)
+          |> Sagax.put("b", fn -> {:ok, "b"} end)
+        end
       end
+
+      {:ok, values, context} = OkSaga.execute(%{}, %{}, [])
+
+      assert values == %{"a" => "a", "b" => "b"}
+      assert context == %{}
     end
 
-    {:ok, values, context} = OkSaga.execute(%{}, %{}, [])
+    test "executes a erroneous saga" do
+      defmodule ErrorSaga do
+        use Sagax.Builder
 
-    assert values == %{"a" => "a", "b" => "b"}
-    assert context == %{}
+        def new(args, context, opts) do
+          Sagax.new(args: args, context: context, opts: opts)
+          |> Sagax.put("a", fn -> {:ok, "a"} end)
+          |> Sagax.put("b", fn -> {:error, "b"} end)
+        end
+      end
+
+      {:error, errors, context} = ErrorSaga.execute(%{}, %{}, [])
+
+      assert [%Sagax.Error{error: "b", path: "b"}] = errors
+      assert context == %{}
+    end
+
+    test "executes a halted saga" do
+      defmodule HaltSaga do
+        use Sagax.Builder
+
+        def new(args, context, opts) do
+          Sagax.new(args: args, context: context, opts: opts)
+          |> Sagax.put("a", fn -> {:ok, "a"} end)
+          |> Sagax.put("b", fn -> {:halt, "b"} end)
+          |> Sagax.put("c", fn -> {:ok, "c"} end)
+        end
+      end
+
+      {:halt, values, context} = HaltSaga.execute(%{}, %{}, [])
+
+      assert values == %{"a" => "a", "b" => "b"}
+      assert context == %{}
+    end
+
+    test "returns context as 3rd tuple element" do
+      defmodule MetaSaga do
+        use Sagax.Builder
+
+        def new(args, context, opts) do
+          Sagax.new(args: args, context: context, opts: opts)
+          |> Sagax.put("a", fn -> {:ok, "a", %{some: "context"}} end)
+          |> Sagax.put("b", fn -> {:ok, "b", %{more: "context"}} end)
+        end
+      end
+
+      {:ok, values, context} = MetaSaga.execute(%{}, %{ctx: %{my: "context"}}, [])
+
+      assert values == %{"a" => "a", "b" => "b"}
+      assert %{ctx: %{my: "context"}, some: "context", more: "context"} = context
+    end
   end
 
-  test "executes a erroneous saga" do
-    defmodule ErrorSaga do
-      alias Sagax.Next, as: Sagax
+  describe "use/3" do
+    test "supports an empty builder" do
+      defmodule Use1Saga do
+        use Sagax.Builder
 
-      use Sagax.Builder
-
-      defp new(args, context, opts) do
-        Sagax.new(args: args, context: context, opts: opts)
-        |> Sagax.put("a", fn -> {:ok, "a"} end)
-        |> Sagax.put("b", fn -> {:error, "b"} end)
+        def new(args, context, opts) do
+          Sagax.new(args: args, context: context, opts: opts)
+          |> Sagax.put("a", fn -> {:ok, "a"} end)
+          |> Sagax.put("b", fn -> {:ok, "b"} end)
+        end
       end
+
+      assert %Sagax{value: %{"ab" => %{"a" => "a", "b" => "b"}}} =
+               Sagax.new()
+               |> Sagax.put("ab", Use1Saga.use())
+               |> Sagax.execute()
     end
 
-    {:error, errors, context} = ErrorSaga.execute(%{}, %{}, [])
+    test "supports args and opts modification" do
+      defmodule Use2Saga do
+        use Sagax.Builder
 
-    assert [%Sagax.Next.Error{error: "b", path: "b"}] = errors
-    assert context == %{}
-  end
-
-  test "executes a halted saga" do
-    defmodule HaltSaga do
-      alias Sagax.Next, as: Sagax
-
-      use Sagax.Builder
-
-      defp new(args, context, opts) do
-        Sagax.new(args: args, context: context, opts: opts)
-        |> Sagax.put("a", fn -> {:ok, "a"} end)
-        |> Sagax.put("b", fn -> {:halt, "b"} end)
-        |> Sagax.put("c", fn -> {:ok, "c"} end)
+        def new(args, _context, opts) do
+          assert %{hello: "world"} = args
+          assert [foo: :bar] = opts
+        end
       end
+
+      Sagax.new(args: %{greeting: "world"})
+      |> Sagax.run(Use2Saga.use(fn _, args -> %{hello: args.greeting} end, foo: :bar))
+      |> Sagax.execute()
     end
-
-    {:halt, values, context} = HaltSaga.execute(%{}, %{}, [])
-
-    assert values == %{"a" => "a", "b" => "b"}
-    assert context == %{}
-  end
-
-  test "returns context as 3rd tuple element" do
-    defmodule MetaSaga do
-      alias Sagax.Next, as: Sagax
-
-      use Sagax.Builder
-
-      defp new(args, context, opts) do
-        Sagax.new(args: args, context: context, opts: opts)
-        |> Sagax.put("a", fn -> {:ok, "a", %{some: "context"}} end)
-        |> Sagax.put("b", fn -> {:ok, "b", %{more: "context"}} end)
-      end
-    end
-
-    {:ok, values, context} = MetaSaga.execute(%{}, %{ctx: %{my: "context"}}, [])
-
-    assert values == %{"a" => "a", "b" => "b"}
-    assert %{ctx: %{my: "context"}, some: "context", more: "context"} = context
   end
 end

--- a/test/next/builder_test.exs
+++ b/test/next/builder_test.exs
@@ -74,9 +74,9 @@ defmodule Sagax.Next.BuilderTest do
     end
   end
 
-  describe "use/3" do
+  describe "compose/3" do
     test "supports an empty builder" do
-      defmodule Use1Saga do
+      defmodule Compose1Saga do
         use Sagax.Builder
 
         def new(args, context, opts) do
@@ -88,12 +88,12 @@ defmodule Sagax.Next.BuilderTest do
 
       assert %Sagax{value: %{"ab" => %{"a" => "a", "b" => "b"}}} =
                Sagax.new()
-               |> Sagax.put("ab", Use1Saga.use())
+               |> Sagax.put("ab", Compose1Saga.compose())
                |> Sagax.execute()
     end
 
     test "supports args and opts modification" do
-      defmodule Use2Saga do
+      defmodule Compose2Saga do
         use Sagax.Builder
 
         def new(args, _context, opts) do
@@ -103,7 +103,7 @@ defmodule Sagax.Next.BuilderTest do
       end
 
       Sagax.new(args: %{greeting: "world"})
-      |> Sagax.run(Use2Saga.use(fn _, args -> %{hello: args.greeting} end, foo: :bar))
+      |> Sagax.run(Compose2Saga.compose(fn _, args -> %{hello: args.greeting} end, foo: :bar))
       |> Sagax.execute()
     end
   end


### PR DESCRIPTION
Adds a new function to make composing nested sagas easier:

```elixir
Sagax.new(args: args, context: context, opts: opts)
|> Sagax.put(:user, &create_user/3)
|> Sagax.put(:entity, CreateEntity.compose(&Map.merge(&2.entity, %{ref_id: &1.user.id})))
```