### PR TITLE
Start with fresh values for nested sagas

### DIFF
--- a/lib/next.ex
+++ b/lib/next.ex
@@ -19,7 +19,9 @@ defmodule Sagax.Next do
           state: :new | :ok | :error,
           tx: transaction(),
           value: map() | list() | nil,
-          opts: Keyword.t() | []
+          opts: Keyword.t() | [],
+          parent_saga_id: integer(),
+          nested_key: any()
         }
 
   defstruct args: nil,
@@ -31,7 +33,9 @@ defmodule Sagax.Next do
             state: :new,
             tx: nil,
             value: nil,
-            opts: []
+            opts: [],
+            parent_saga_id: nil,
+            nested_key: nil
 
   @doc """
   Creates a new saga.

--- a/lib/next/executer.ex
+++ b/lib/next/executer.ex
@@ -33,11 +33,13 @@ defmodule Sagax.Next.Executer do
       cond do
         state.values == %{} ->
           nil
-        path != []  ->
+
+        path != [] ->
           get_in(state.values, path)
+
         true ->
           state.values
-        end
+      end
 
     effect = op(operation, :effect)
 

--- a/lib/next/state.ex
+++ b/lib/next/state.ex
@@ -31,12 +31,12 @@ defmodule Sagax.Next.State do
     key = Keyword.get(op(operation, :opts), :key)
     parent_saga_id = op(operation, :saga_id)
 
-    saga =
-      %{
-        saga
-        | parent_saga_id: parent_saga_id,
-          nested_key: key
-      }
+    saga = %{
+      saga
+      | parent_saga_id: parent_saga_id,
+        nested_key: key
+    }
+
     sagas = Map.put(state.sagas, saga.id, saga)
 
     # Put future values of nested saga(s) into corresponding keys of the parent saga(s).
@@ -197,7 +197,12 @@ defmodule Sagax.Next.State do
     %RuntimeError{message: message}
   end
 
-  def build_key_path(state, %{parent_saga_id: parent_saga_id, nested_key: nested_key} = _saga, path) when not is_nil(nested_key) do
+  def build_key_path(
+        state,
+        %{parent_saga_id: parent_saga_id, nested_key: nested_key} = _saga,
+        path
+      )
+      when not is_nil(nested_key) do
     path = [nested_key | path]
     parent_saga = state.sagas[parent_saga_id]
 
@@ -209,7 +214,7 @@ defmodule Sagax.Next.State do
   def update_values(%State{} = state, saga, key, result) do
     if saga.parent_saga_id do
       path = build_key_path(state, saga, [])
-      update_in(state.values, path, &(Map.merge(&1 || %{}, %{key => result})))
+      update_in(state.values, path, &Map.merge(&1 || %{}, %{key => result}))
     else
       Map.put(state.values, key, result)
     end

--- a/test/next/executer_test.exs
+++ b/test/next/executer_test.exs
@@ -140,7 +140,13 @@ defmodule Sagax.Next.ExecuterTest do
       nested_saga_1 =
         Sagax.new()
         |> Sagax.put("c", nested_saga_2)
-        |> Sagax.put("c1", assert_value_effect(%{"c" => %{"d" => %{"e" => %{"f" => "f", "g" => "g"}}}}, {:ok, "c1"}))
+        |> Sagax.put(
+          "c1",
+          assert_value_effect(
+            %{"c" => %{"d" => %{"e" => %{"f" => "f", "g" => "g"}}}},
+            {:ok, "c1"}
+          )
+        )
 
       saga =
         Sagax.new()
@@ -148,7 +154,11 @@ defmodule Sagax.Next.ExecuterTest do
         |> Sagax.put("b", nested_saga_1)
 
       assert %Sagax{state: :ok, value: value} = Executer.execute(saga)
-      assert value == %{"a" => "a", "b" => %{"c" => %{"d" => %{"e" => %{"f" => "f", "g" => "g"}}}, "c1" => "c1"}}
+
+      assert value == %{
+               "a" => "a",
+               "b" => %{"c" => %{"d" => %{"e" => %{"f" => "f", "g" => "g"}}}, "c1" => "c1"}
+             }
     end
 
     test "halts execution when a step returns :halt", %{log: log} do

--- a/test/next/executer_test.exs
+++ b/test/next/executer_test.exs
@@ -105,12 +105,12 @@ defmodule Sagax.Next.ExecuterTest do
     test "execute nested sagas", %{log: l} do
       nested_saga_1 =
         Sagax.new()
-        |> Sagax.put("c1", assert_value_effect(%{"b" => nil}, {:ok, "c1"}))
-        |> Sagax.put("c2", assert_value_effect(%{"b" => %{"c1" => "c1"}}, {:ok, "c2"}))
+        |> Sagax.put("c1", assert_value_effect(nil, {:ok, "c1"}))
+        |> Sagax.put("c2", assert_value_effect(%{"c1" => "c1"}, {:ok, "c2"}))
 
       nested_saga_2 =
         Sagax.new()
-        |> Sagax.put("d", assert_value_effect(%{"f" => nil}, {:ok, "d"}))
+        |> Sagax.put("d", assert_value_effect(nil, {:ok, "d"}))
 
       saga =
         Sagax.new()
@@ -121,6 +121,34 @@ defmodule Sagax.Next.ExecuterTest do
       assert %Sagax{state: :ok, value: value} = Executer.execute(saga)
       assert_log l, ["a", "b"]
       assert value == %{"a" => "a", "b" => %{"c1" => "c1", "c2" => "c2"}, "f" => %{"d" => "d"}}
+    end
+
+    test "execute deeply execute nested sagas" do
+      nested_saga_4 =
+        Sagax.new()
+        |> Sagax.put("f", assert_value_effect(nil, {:ok, "f"}))
+        |> Sagax.put("g", assert_value_effect(%{"f" => "f"}, {:ok, "g"}))
+
+      nested_saga_3 =
+        Sagax.new()
+        |> Sagax.put("e", nested_saga_4)
+
+      nested_saga_2 =
+        Sagax.new()
+        |> Sagax.put("d", nested_saga_3)
+
+      nested_saga_1 =
+        Sagax.new()
+        |> Sagax.put("c", nested_saga_2)
+        |> Sagax.put("c1", assert_value_effect(%{"c" => %{"d" => %{"e" => %{"f" => "f", "g" => "g"}}}}, {:ok, "c1"}))
+
+      saga =
+        Sagax.new()
+        |> Sagax.put("a", assert_value_effect(nil, {:ok, "a"}))
+        |> Sagax.put("b", nested_saga_1)
+
+      assert %Sagax{state: :ok, value: value} = Executer.execute(saga)
+      assert value == %{"a" => "a", "b" => %{"c" => %{"d" => %{"e" => %{"f" => "f", "g" => "g"}}}, "c1" => "c1"}}
     end
 
     test "halts execution when a step returns :halt", %{log: log} do


### PR DESCRIPTION
Currently, nested sagas see the results accumulated so far by the outer saga
which is not intended behaviour.
Also, nested more than one saga is somewhat broken currently.
This PR fixes both issues allowing nesting as many sagas as one may want
and not leaking data from outer saga(s) to the current one.

Closes #23 
